### PR TITLE
Fix doc on web page with invalid maven repos for OpenIMAJ driver

### DIFF
--- a/webcam-capture-pages/src/site/index.html
+++ b/webcam-capture-pages/src/site/index.html
@@ -235,7 +235,7 @@ In such a case one have to add those repositories to project's POM:
     &lt;/repository&gt;
     &lt;repository&gt;
         &lt;id&gt;OpenIMAJ Snapshots maven repository&lt;/id&gt;
-        &lt;url&gt;http://octopussy.ecs.soton.ac.uk/m2/snapshots/&lt;/url&gt;
+        &lt;url&gt;http://snapshots.openimaj.org&lt;/url&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;
 </pre>


### PR DESCRIPTION
I recently tried to build, and noticed the old 'octopussy' maven repositories are no longer available. I updated the web page to use the repo I found in the pom.xml in the source tree (and I verified I could then build successfully). 

I apologize, but my editor mangled a unicode character at the top of this index.html file, and I had to redo the edit (and I managed to get the url wrong the second time). I think the final edit is correct. My intent was to remote the 2 'octopussy' repos, and add the snapshot openimag repo.
