### PR TITLE
Intellij IDEA project files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ pom.xml~
 .project
 .classpath
 README.md~
-
+*.iml
+.idea/
+*.ipr
+*.iws

--- a/webcam-capture-examples/webcam-capture-onejar/pom.xml
+++ b/webcam-capture-examples/webcam-capture-onejar/pom.xml
@@ -14,7 +14,7 @@
 	    <dependency>
 	        <groupId>com.github.sarxos</groupId>
 	        <artifactId>webcam-capture</artifactId>
-	        <version>0.3.10-SNAPSHOT</version>
+	        <version>0.3.12-SNAPSHOT</version>
 	    </dependency>
 	</dependencies>
 


### PR DESCRIPTION
I think it worth to add IntelliJ IDEA project files to ```.gitignore```.

Another commit fixes incorrect webcam-capture dependency version in onejar example.