### PR TITLE
Fix NPE in WebcamDiscoveryService

### DIFF
--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamDiscoveryService.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamDiscoveryService.java
@@ -381,6 +381,9 @@ public class WebcamDiscoveryService implements Runnable {
 
 		stop();
 
+		if (webcams == null)
+			return;
+
 		// dispose all webcams
 
 		Iterator<Webcam> wi = webcams.iterator();


### PR DESCRIPTION
While testing a new webcam driver that I wrote, I came across an NPE during the call to `Webcam.setDriver()`