### PR TITLE
Added Max threshold to the default algorithm, and added a "do not engage" default algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ README.md~
 .idea/
 *.ipr
 *.iws
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>webcam-capture-parent</artifactId>
-	<version>0.3.12-SNAPSHOT</version>
+	<version>0.3.13</version>
 	<packaging>pom</packaging>
 
 	<name>Webcam Capture Parent POM</name>

--- a/webcam-capture-addons/pom.xml
+++ b/webcam-capture-addons/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-parent</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-addons</artifactId>

--- a/webcam-capture-addons/webcam-capture-addon-spycam/pom.xml
+++ b/webcam-capture-addons/webcam-capture-addon-spycam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-addons</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-addon-spycam</artifactId>

--- a/webcam-capture-addons/webcam-capture-addon-swt/pom.xml
+++ b/webcam-capture-addons/webcam-capture-addon-swt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-addons</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-addon-swt</artifactId>

--- a/webcam-capture-drivers/driver-ffmpeg-cli/pom.xml
+++ b/webcam-capture-drivers/driver-ffmpeg-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-driver-ffmpeg-cli</artifactId>

--- a/webcam-capture-drivers/driver-fswebcam/pom.xml
+++ b/webcam-capture-drivers/driver-fswebcam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-driver-fswebcam</artifactId>

--- a/webcam-capture-drivers/driver-gst1/pom.xml
+++ b/webcam-capture-drivers/driver-gst1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-driver-gst1</artifactId>

--- a/webcam-capture-drivers/driver-gstreamer/pom.xml
+++ b/webcam-capture-drivers/driver-gstreamer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 	
 	<artifactId>webcam-capture-driver-gstreamer</artifactId>

--- a/webcam-capture-drivers/driver-ipcam/pom.xml
+++ b/webcam-capture-drivers/driver-ipcam/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 	
 	<artifactId>webcam-capture-driver-ipcam</artifactId>

--- a/webcam-capture-drivers/driver-ipcam/src/examples/java/JpegDasdingStudioExample.java
+++ b/webcam-capture-drivers/driver-ipcam/src/examples/java/JpegDasdingStudioExample.java
@@ -9,6 +9,7 @@ import javax.swing.JFrame;
 
 import com.github.sarxos.webcam.Webcam;
 import com.github.sarxos.webcam.WebcamPanel;
+import com.github.sarxos.webcam.WebcamPanel.DrawMode;
 import com.github.sarxos.webcam.ds.ipcam.IpCamDriver;
 import com.github.sarxos.webcam.ds.ipcam.IpCamStorage;
 
@@ -49,7 +50,7 @@ public class JpegDasdingStudioExample {
 		for (Webcam webcam : Webcam.getWebcams()) {
 
 			WebcamPanel panel = new WebcamPanel(webcam, new Dimension(256, 144), false);
-			panel.setFillArea(true);
+			panel.setDrawMode(DrawMode.FIT);
 			panel.setFPSLimited(true);
 			panel.setFPSLimit(0.2); // 0.2 FPS = 1 frame per 5 seconds
 			panel.setBorder(BorderFactory.createEmptyBorder());

--- a/webcam-capture-drivers/driver-ipcam/src/main/java/com/github/sarxos/webcam/ds/ipcam/IpCamDevice.java
+++ b/webcam-capture-drivers/driver-ipcam/src/main/java/com/github/sarxos/webcam/ds/ipcam/IpCamDevice.java
@@ -23,6 +23,8 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.protocol.ClientContext;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.params.CoreProtocolPNames;
+import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.protocol.BasicHttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,7 +207,7 @@ public class IpCamDevice implements WebcamDevice {
 
 	private Dimension[] sizes = null;
 	private Dimension size = null;
-
+	
 	public IpCamDevice(String name, String url, IpCamMode mode) throws MalformedURLException {
 		this(name, new URL(url), mode, null);
 	}
@@ -233,6 +235,10 @@ public class IpCamDevice implements WebcamDevice {
 			AuthScope scope = new AuthScope(new HttpHost(url.getHost().toString()));
 			client.getCredentialsProvider().setCredentials(scope, auth);
 		}
+	}
+
+	public IpCamHttpClient getClient() {
+		return client;
 	}
 
 	protected static final URL toURL(String url) {
@@ -428,7 +434,7 @@ public class IpCamDevice implements WebcamDevice {
 		}
 
 		HttpHead head = new HttpHead(uri);
-
+		
 		HttpResponse response = null;
 		try {
 			response = client.execute(head);

--- a/webcam-capture-drivers/driver-ipcam/src/main/java/com/github/sarxos/webcam/ds/ipcam/impl/IpCamHttpClient.java
+++ b/webcam-capture-drivers/driver-ipcam/src/main/java/com/github/sarxos/webcam/ds/ipcam/impl/IpCamHttpClient.java
@@ -4,6 +4,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
+import org.apache.http.params.HttpConnectionParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,12 +26,15 @@ public class IpCamHttpClient extends DefaultHttpClient {
 	 */
 	public static final String PROXY_PORT_KEY = "http.proxyPort";
 
+	public static final String SO_TIMEOUT = "http.socket.timeout";
+	public static final String CONNECTION_TIMEOUT = "http.connection.timeout";
+
 	private HttpHost proxy = null;
 
 	public IpCamHttpClient() {
 
 		super(new PoolingClientConnectionManager());
-
+		
 		// configure proxy if any
 
 		String proxyHost = System.getProperty(PROXY_HOST_KEY);
@@ -43,6 +47,16 @@ public class IpCamHttpClient extends DefaultHttpClient {
 			proxy = new HttpHost(proxyHost, Integer.parseInt(proxyPort), "http");
 
 			setProxy(proxy);
+		}
+
+		String soTimeout = System.getProperty(SO_TIMEOUT);
+		if (soTimeout != null) {
+			HttpConnectionParams.setSoTimeout(getParams(), Integer.parseInt(soTimeout));
+		}
+
+		String connectionTimeout = System.getProperty(CONNECTION_TIMEOUT);
+		if (connectionTimeout != null) {
+			HttpConnectionParams.setConnectionTimeout(getParams(), Integer.parseInt(connectionTimeout));
 		}
 	}
 

--- a/webcam-capture-drivers/driver-javacv/pom.xml
+++ b/webcam-capture-drivers/driver-javacv/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-driver-javacv</artifactId>

--- a/webcam-capture-drivers/driver-jmf/pom.xml
+++ b/webcam-capture-drivers/driver-jmf/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-driver-jmf</artifactId>

--- a/webcam-capture-drivers/driver-lti-civil/pom.xml
+++ b/webcam-capture-drivers/driver-lti-civil/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-driver-lti-civil</artifactId>

--- a/webcam-capture-drivers/driver-openimaj/pom.xml
+++ b/webcam-capture-drivers/driver-openimaj/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-driver-openimaj</artifactId>

--- a/webcam-capture-drivers/driver-v4l4j/pom.xml
+++ b/webcam-capture-drivers/driver-v4l4j/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 	
 	<artifactId>webcam-capture-driver-v4l4j</artifactId>

--- a/webcam-capture-drivers/driver-vlcj/pom.xml
+++ b/webcam-capture-drivers/driver-vlcj/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-drivers</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 	
 	<artifactId>webcam-capture-driver-vlcj</artifactId>

--- a/webcam-capture-drivers/pom.xml
+++ b/webcam-capture-drivers/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-parent</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-drivers</artifactId>

--- a/webcam-capture-examples/pom.xml
+++ b/webcam-capture-examples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-parent</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-examples</artifactId>

--- a/webcam-capture-examples/webcam-capture-applet/pom.xml
+++ b/webcam-capture-examples/webcam-capture-applet/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-applet</artifactId>

--- a/webcam-capture-examples/webcam-capture-detect-face/pom.xml
+++ b/webcam-capture-examples/webcam-capture-detect-face/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-detect-face</artifactId>

--- a/webcam-capture-examples/webcam-capture-executable/pom.xml
+++ b/webcam-capture-examples/webcam-capture-executable/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-executable</artifactId>

--- a/webcam-capture-examples/webcam-capture-javafx-fxml/pom.xml
+++ b/webcam-capture-examples/webcam-capture-javafx-fxml/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-javafx-fxml</artifactId>

--- a/webcam-capture-examples/webcam-capture-javafx/pom.xml
+++ b/webcam-capture-examples/webcam-capture-javafx/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-javafx</artifactId>

--- a/webcam-capture-examples/webcam-capture-live-streaming/pom.xml
+++ b/webcam-capture-examples/webcam-capture-live-streaming/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-live-streaming</artifactId>

--- a/webcam-capture-examples/webcam-capture-manycams/pom.xml
+++ b/webcam-capture-examples/webcam-capture-manycams/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-manycams</artifactId>

--- a/webcam-capture-examples/webcam-capture-motiondetector/pom.xml
+++ b/webcam-capture-examples/webcam-capture-motiondetector/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-motiondetector</artifactId>

--- a/webcam-capture-examples/webcam-capture-onejar/pom.xml
+++ b/webcam-capture-examples/webcam-capture-onejar/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-onejar</artifactId>
@@ -14,7 +14,7 @@
 	    <dependency>
 	        <groupId>com.github.sarxos</groupId>
 	        <artifactId>webcam-capture</artifactId>
-	        <version>0.3.12-SNAPSHOT</version>
+	        <version>0.3.13</version>
 	    </dependency>
 	</dependencies>
 

--- a/webcam-capture-examples/webcam-capture-painter/pom.xml
+++ b/webcam-capture-examples/webcam-capture-painter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-painter</artifactId>

--- a/webcam-capture-examples/webcam-capture-qrcode/pom.xml
+++ b/webcam-capture-examples/webcam-capture-qrcode/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-qrcode</artifactId>

--- a/webcam-capture-examples/webcam-capture-swt-awt/pom.xml
+++ b/webcam-capture-examples/webcam-capture-swt-awt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-swt-awt</artifactId>

--- a/webcam-capture-examples/webcam-capture-transformer/pom.xml
+++ b/webcam-capture-examples/webcam-capture-transformer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-transformer</artifactId>

--- a/webcam-capture-examples/webcam-capture-video-recording/pom.xml
+++ b/webcam-capture-examples/webcam-capture-video-recording/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-video-recordig</artifactId>

--- a/webcam-capture-examples/webcam-capture-websockets/pom.xml
+++ b/webcam-capture-examples/webcam-capture-websockets/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-examples</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture-example-websockets</artifactId>

--- a/webcam-capture-pages/pom.xml
+++ b/webcam-capture-pages/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-parent</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 	
 	<artifactId>webcam-capture-pages</artifactId>

--- a/webcam-capture/pom.xml
+++ b/webcam-capture/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.sarxos</groupId>
 		<artifactId>webcam-capture-parent</artifactId>
-		<version>0.3.12-SNAPSHOT</version>
+		<version>0.3.13</version>
 	</parent>
 
 	<artifactId>webcam-capture</artifactId>

--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
@@ -401,12 +401,14 @@ public class WebcamMotionDetector {
    */
   public ArrayList<Integer> getThresholds()
   {
-    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm
-        || detectorAlgorithm instanceof WebcamMotionDetectorDefaultWithDNE)
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm)
     {
       return ((WebcamMotionDetectorDefaultAlgorithm) detectorAlgorithm).getThresholds();
     }
-    else
+    else if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultWithDNE)
+    {
+      return ((WebcamMotionDetectorDefaultWithDNE) detectorAlgorithm).getThresholds();
+    } else
     {
       throw new UnsupportedOperationException("This method is only valid for the default detector algorithm");
     }

--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
@@ -388,28 +388,37 @@ public class WebcamMotionDetector {
    * @param rectangle
    */
   public void setDne(Rectangle rectangle) {
-    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
-      ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setDne(rectangle);
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultWithDNE)
+    {
+      ((WebcamMotionDetectorDefaultWithDNE) detectorAlgorithm).setDne(rectangle);
     } else {
       throw new IllegalArgumentException("This algorithm does not support do not engage zone");
     }
   }
-  
-  
-  public ArrayList<Integer> getThresholds() {
-    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
-      return ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).getThresholds();
-    } else {
+
+  /**
+   * @return thresholds
+   */
+  public ArrayList<Integer> getThresholds()
+  {
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm
+        || detectorAlgorithm instanceof WebcamMotionDetectorDefaultWithDNE)
+    {
+      return ((WebcamMotionDetectorDefaultAlgorithm) detectorAlgorithm).getThresholds();
+    }
+    else
+    {
       throw new UnsupportedOperationException("This method is only valid for the default detector algorithm");
     }
   }
 
   /**
-   * Set motion inertia (time when motion is valid). If no value specified
-   * this is set to 2 * interval. To reset to default value,
-   * {@link #clearInertia()} method must be used.
+   * Set motion inertia (time when motion is valid). If no value specified this
+   * is set to 2 * interval. To reset to default value, {@link #clearInertia()}
+   * method must be used.
    *
-   * @param inertia the motion inertia time in milliseconds
+   * @param inertia
+   *          the motion inertia time in milliseconds
    * @see #clearInertia()
    */
   public void setInertia(int inertia) {

--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
@@ -21,438 +21,459 @@ import org.slf4j.LoggerFactory;
  */
 public class WebcamMotionDetector {
 
-	/**
-	 * Logger.
-	 */
-	private static final Logger LOG = LoggerFactory.getLogger(WebcamMotionDetector.class);
+  /**
+   * Logger.
+   */
+  private static final Logger LOG = LoggerFactory.getLogger(WebcamMotionDetector.class);
 
-	/**
-	 * Thread number in pool.
-	 */
-	private static final AtomicInteger NT = new AtomicInteger(0);
+  /**
+   * Thread number in pool.
+   */
+  private static final AtomicInteger NT = new AtomicInteger(0);
 
-	/**
-	 * Thread factory.
-	 */
-	private static final ThreadFactory THREAD_FACTORY = new DetectorThreadFactory();
+  /**
+   * Thread factory.
+   */
+  private static final ThreadFactory THREAD_FACTORY = new DetectorThreadFactory();
 
-	/**
-	 * Default check interval, in milliseconds, set to 500 ms.
-	 */
-	public static final int DEFAULT_INTERVAL = 500;
+  /**
+   * Default check interval, in milliseconds, set to 500 ms.
+   */
+  public static final int DEFAULT_INTERVAL = 500;
 
-	/**
-	 * Create new threads for detector internals.
-	 *
-	 * @author Bartosz Firyn (SarXos)
-	 */
-	private static final class DetectorThreadFactory implements ThreadFactory {
+  /**
+   * Create new threads for detector internals.
+   *
+   * @author Bartosz Firyn (SarXos)
+   */
+  private static final class DetectorThreadFactory implements ThreadFactory {
 
-		@Override
-		public Thread newThread(Runnable runnable) {
-			Thread t = new Thread(runnable, String.format("motion-detector-%d", NT.incrementAndGet()));
-			t.setUncaughtExceptionHandler(WebcamExceptionHandler.getInstance());
-			t.setDaemon(true);
-			return t;
-		}
-	}
+    @Override
+    public Thread newThread(Runnable runnable) {
+      Thread t = new Thread(runnable, String.format("motion-detector-%d", NT.incrementAndGet()));
+      t.setUncaughtExceptionHandler(WebcamExceptionHandler.getInstance());
+      t.setDaemon(true);
+      return t;
+    }
+  }
 
-	/**
-	 * Run motion detector.
-	 *
-	 * @author Bartosz Firyn (SarXos)
-	 */
-	private class Runner implements Runnable {
+  /**
+   * Run motion detector.
+   *
+   * @author Bartosz Firyn (SarXos)
+   */
+  private class Runner implements Runnable {
 
-		@Override
-		public void run() {
+    @Override
+    public void run() {
 
-			running.set(true);
+      running.set(true);
 
-			while (running.get() && webcam.isOpen()) {
-				try {
-					detect();
-					Thread.sleep(interval);
-				} catch (InterruptedException e) {
-					break;
-				} catch (Exception e) {
-					WebcamExceptionHandler.handle(e);
-				}
-			}
+      while (running.get() && webcam.isOpen()) {
+        try {
+          detect();
+          Thread.sleep(interval);
+        } catch (InterruptedException e) {
+          break;
+        } catch (Exception e) {
+          WebcamExceptionHandler.handle(e);
+        }
+      }
 
-			running.set(false);
-		}
-	}
+      running.set(false);
+    }
+  }
 
-	/**
-	 * Change motion to false after specified number of seconds.
-	 *
-	 * @author Bartosz Firyn (SarXos)
-	 */
-	private class Inverter implements Runnable {
+  /**
+   * Change motion to false after specified number of seconds.
+   *
+   * @author Bartosz Firyn (SarXos)
+   */
+  private class Inverter implements Runnable {
 
-		@Override
-		public void run() {
+    @Override
+    public void run() {
 
-			int delay = 0;
+      int delay = 0;
 
-			while (running.get()) {
+      while (running.get()) {
 
-				try {
-					Thread.sleep(10);
-				} catch (InterruptedException e) {
-					break;
-				}
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          break;
+        }
 
-				delay = inertia != -1 ? inertia : 2 * interval;
+        delay = inertia != -1 ? inertia : 2 * interval;
 
-				if (lastMotionTimestamp + delay < System.currentTimeMillis()) {
-					motion = false;
-				}
-			}
-		}
-	}
+        if (lastMotionTimestamp + delay < System.currentTimeMillis()) {
+          motion = false;
+        }
+      }
+    }
+  }
 
-	/**
-	 * Executor.
-	 */
-	private final ExecutorService executor = Executors.newFixedThreadPool(2, THREAD_FACTORY);
+  /**
+   * Executor.
+   */
+  private final ExecutorService executor = Executors.newFixedThreadPool(2, THREAD_FACTORY);
 
-	/**
-	 * Motion listeners.
-	 */
-	private final List<WebcamMotionListener> listeners = new ArrayList<WebcamMotionListener>();
+  /**
+   * Motion listeners.
+   */
+  private final List<WebcamMotionListener> listeners = new ArrayList<WebcamMotionListener>();
 
-	/**
-	 * Is detector running?
-	 */
-	private final AtomicBoolean running = new AtomicBoolean(false);
+  /**
+   * Is detector running?
+   */
+  private final AtomicBoolean running = new AtomicBoolean(false);
 
-	/**
-	 * Is motion?
-	 */
-	private volatile boolean motion = false;
+  /**
+   * Is motion?
+   */
+  private volatile boolean motion = false;
 
-	/**
-	 * Previously captured image.
-	 */
-	private BufferedImage previousOriginal = null;
+  /**
+   * Previously captured image.
+   */
+  private BufferedImage previousOriginal = null;
 
-	/**
-	 * Previously captured image with blur and gray filters applied.
-	 */
-	private BufferedImage previousModified = null;
-	
-	/**
-	 * Webcam to be used to detect motion.
-	 */
-	private Webcam webcam = null;
+  /**
+   * Previously captured image with blur and gray filters applied.
+   */
+  private BufferedImage previousModified = null;
 
-	/**
-	 * Motion check interval (1000 ms by default).
-	 */
-	private volatile int interval = DEFAULT_INTERVAL;
+  /**
+   * Webcam to be used to detect motion.
+   */
+  private Webcam webcam = null;
 
-	/**
-	 * How long motion is valid (in milliseconds). Default value is 2 seconds.
-	 */
-	private volatile int inertia = -1;
+  /**
+   * Motion check interval (1000 ms by default).
+   */
+  private volatile int interval = DEFAULT_INTERVAL;
 
-	/**
-	 * Timestamp when motion has been observed last time.
-	 */
-	private volatile long lastMotionTimestamp = 0;
+  /**
+   * How long motion is valid (in milliseconds). Default value is 2 seconds.
+   */
+  private volatile int inertia = -1;
 
-	/**
-	 * Implementation of motion detection algorithm.
-	 */
-	private final WebcamMotionDetectorAlgorithm detectorAlgorithm;
+  /**
+   * Timestamp when motion has been observed last time.
+   */
+  private volatile long lastMotionTimestamp = 0;
 
-	/**
-	 * Create motion detector. Will open webcam if it is closed. 
-	 * 
-	 * @param webcam web camera instance
-	 * @param motion detector algorithm implementation 
-	 * @param interval the check interval
-	 */
-	public WebcamMotionDetector(Webcam webcam, WebcamMotionDetectorAlgorithm detectorAlgorithm, int interval) {
-		this.webcam = webcam;
-		this.detectorAlgorithm = detectorAlgorithm;
-		setInterval(interval);
-	}
-	
-	/**
-	 * Create motion detector. Will open webcam if it is closed. 
-	 * Uses WebcamMotionDetectorDefaultAlgorithm for motion detection. 
-	 *
-	 * @param webcam web camera instance
-	 * @param pixelThreshold intensity threshold (0 - 255)
-	 * @param areaThreshold percentage threshold of image covered by motion
-	 * @param interval the check interval
-	 */
-	public WebcamMotionDetector(Webcam webcam, int pixelThreshold, double areaThreshold, int interval) {
-		this(webcam, new WebcamMotionDetectorDefaultAlgorithm(pixelThreshold, areaThreshold), interval);
-	}
+  /**
+   * Implementation of motion detection algorithm.
+   */
+  private final WebcamMotionDetectorAlgorithm detectorAlgorithm;
 
-	/**
-	 * Create motion detector with default parameter inertia = 0.
-	 * Uses WebcamMotionDetectorDefaultAlgorithm for motion detection. 
-	 *
-	 * @param webcam web camera instance
-	 * @param pixelThreshold intensity threshold (0 - 255)
-	 * @param areaThreshold percentage threshold of image covered by motion (0 -
-	 *            100)
-	 */
-	public WebcamMotionDetector(Webcam webcam, int pixelThreshold, double areaThreshold) {
-		this(webcam, pixelThreshold, areaThreshold, DEFAULT_INTERVAL);
-	}
+  /**
+   * Create motion detector. Will open webcam if it is closed. 
+   * 
+   * @param webcam web camera instance
+   * @param motion detector algorithm implementation 
+   * @param interval the check interval
+   */
+  public WebcamMotionDetector(Webcam webcam, WebcamMotionDetectorAlgorithm detectorAlgorithm, int interval) {
+    this.webcam = webcam;
+    this.detectorAlgorithm = detectorAlgorithm;
+    setInterval(interval);
+  }
 
-	/**
-	 * Create motion detector with default parameter inertia = 0.
-	 * Uses WebcamMotionDetectorDefaultAlgorithm for motion detection. 
-	 *
-	 * @param webcam web camera instance
-	 * @param pixelThreshold intensity threshold (0 - 255)
-	 */
-	public WebcamMotionDetector(Webcam webcam, int pixelThreshold) {
-		this(webcam, pixelThreshold, WebcamMotionDetectorDefaultAlgorithm.DEFAULT_AREA_THREASHOLD);
-	}
+  /**
+   * Create motion detector. Will open webcam if it is closed. 
+   * Uses WebcamMotionDetectorDefaultAlgorithm for motion detection. 
+   *
+   * @param webcam web camera instance
+   * @param pixelThreshold intensity threshold (0 - 255)
+   * @param areaThreshold percentage threshold of image covered by motion
+   * @param interval the check interval
+   */
+  public WebcamMotionDetector(Webcam webcam, int pixelThreshold, double areaThreshold, int interval) {
+    this(webcam, new WebcamMotionDetectorDefaultAlgorithm(pixelThreshold, areaThreshold), interval);
+  }
 
-	/**
-	 * Create motion detector with default parameters - threshold = 25, inertia
-	 * = 0.
-	 *
-	 * @param webcam web camera instance
-	 */
-	public WebcamMotionDetector(Webcam webcam) {
-		this(webcam, WebcamMotionDetectorDefaultAlgorithm.DEFAULT_PIXEL_THREASHOLD);
-	}
+  /**
+   * Create motion detector with default parameter inertia = 0.
+   * Uses WebcamMotionDetectorDefaultAlgorithm for motion detection. 
+   *
+   * @param webcam web camera instance
+   * @param pixelThreshold intensity threshold (0 - 255)
+   * @param areaThreshold percentage threshold of image covered by motion (0 -
+   *            100)
+   */
+  public WebcamMotionDetector(Webcam webcam, int pixelThreshold, double areaThreshold) {
+    this(webcam, pixelThreshold, areaThreshold, DEFAULT_INTERVAL);
+  }
 
-	public void start() {
-		if (running.compareAndSet(false, true)) {
-			webcam.open();
-			executor.submit(new Runner());
-			executor.submit(new Inverter());
-		}
-	}
+  /**
+   * Create motion detector with default parameter inertia = 0.
+   * Uses WebcamMotionDetectorDefaultAlgorithm for motion detection. 
+   *
+   * @param webcam web camera instance
+   * @param pixelThreshold intensity threshold (0 - 255)
+   */
+  public WebcamMotionDetector(Webcam webcam, int pixelThreshold) {
+    this(webcam, pixelThreshold, WebcamMotionDetectorDefaultAlgorithm.DEFAULT_AREA_THREASHOLD);
+  }
 
-	public void stop() {
-		if (running.compareAndSet(true, false)) {
-			webcam.close();
-			executor.shutdownNow();
-		}
-	}
+  /**
+   * Create motion detector with default parameters - threshold = 25, inertia
+   * = 0.
+   *
+   * @param webcam web camera instance
+   */
+  public WebcamMotionDetector(Webcam webcam) {
+    this(webcam, WebcamMotionDetectorDefaultAlgorithm.DEFAULT_PIXEL_THREASHOLD);
+  }
 
-	protected void detect() {
+  public void start() {
+    if (running.compareAndSet(false, true)) {
+      webcam.open();
+      executor.submit(new Runner());
+      executor.submit(new Inverter());
+    }
+  }
 
-		if (!webcam.isOpen()) {
-			motion = false;
-			return;
-		}
+  public void stop() {
+    if (running.compareAndSet(true, false)) {
+      webcam.close();
+      executor.shutdownNow();
+    }
+  }
 
-		BufferedImage currentOriginal = webcam.getImage();
+  protected void detect() {
 
-		if (currentOriginal == null) {
-			motion = false;
-			return;
-		}
-
-		BufferedImage currentModified = detectorAlgorithm.prepareImage(currentOriginal);
-		
-		boolean movementDetected = detectorAlgorithm.detect(previousModified, currentModified);
-
-		if (movementDetected) {
-			motion = true;
-			lastMotionTimestamp = System.currentTimeMillis();
-			notifyMotionListeners(currentOriginal);
-		}
-		
-		previousOriginal = currentOriginal;
-		previousModified = currentModified;
-	}
-
-	/**
-	 * Will notify all attached motion listeners.
-	 * @param image with the motion detected
-	 */
-	private void notifyMotionListeners(BufferedImage currentOriginal) {
-		WebcamMotionEvent wme = new WebcamMotionEvent(this, previousOriginal, currentOriginal, detectorAlgorithm.getArea(), detectorAlgorithm.getCog(), detectorAlgorithm.getPoints());
-		for (WebcamMotionListener l : listeners) {
-			try {
-				l.motionDetected(wme);
-			} catch (Exception e) {
-				WebcamExceptionHandler.handle(e);
-			}
-		}
-	}
-
-	/**
-	 * Add motion listener.
-	 *
-	 * @param l listener to add
-	 * @return true if listeners list has been changed, false otherwise
-	 */
-	public boolean addMotionListener(WebcamMotionListener l) {
-		return listeners.add(l);
-	}
-
-	/**
-	 * @return All motion listeners as array
-	 */
-	public WebcamMotionListener[] getMotionListeners() {
-		return listeners.toArray(new WebcamMotionListener[listeners.size()]);
-	}
-
-	/**
-	 * Removes motion listener.
-	 *
-	 * @param l motion listener to remove
-	 * @return true if listener was available on the list, false otherwise
-	 */
-	public boolean removeMotionListener(WebcamMotionListener l) {
-		return listeners.remove(l);
-	}
-
-	/**
-	 * @return Motion check interval in milliseconds
-	 */
-	public int getInterval() {
-		return interval;
-	}
-
-	/**
-	 * Motion check interval in milliseconds. After motion is detected, it's
-	 * valid for time which is equal to value of 2 * interval.
-	 *
-	 * @param interval the new motion check interval (ms)
-	 * @see #DEFAULT_INTERVAL
-	 */
-	public void setInterval(int interval) {
-
-		if (interval < 100) {
-			throw new IllegalArgumentException("Motion check interval cannot be less than 100 ms");
-		}
-
-		this.interval = interval;
-	}
-
-	/**
-	 * Sets pixelThreshold to the underlying detector algorithm, but only if the
-	 * algorithm is (or extends) WebcamMotionDetectorDefaultAlgorithm
-	 * 
-	 * @see WebcamMotionDetectorDefaultAlgorithm#setPixelThreshold(int)
-	 * 
-	 * @param threshold the pixel intensity difference threshold
-	 */
-	public void setPixelThreshold(int threshold) {
-		if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
-			((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setPixelThreshold(threshold);
-		}
-	}
-
-	/**
-	 * Sets areaThreshold to the underlying detector algorithm, but only if the
-	 * algorithm is (or extends) WebcamMotionDetectorDefaultAlgorithm
-	 * 
-	 * @see WebcamMotionDetectorDefaultAlgorithm#setAreaThreshold(double)
-	 * 
-	 * @param threshold the percentage fraction of image area
-	 */
-	public void setAreaThreshold(double threshold) {
-		if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
-			((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setAreaThreshold(threshold);
-		}
-	}
-
-	/**
-	 * Set motion inertia (time when motion is valid). If no value specified
-	 * this is set to 2 * interval. To reset to default value,
-	 * {@link #clearInertia()} method must be used.
-	 *
-	 * @param inertia the motion inertia time in milliseconds
-	 * @see #clearInertia()
-	 */
-	public void setInertia(int inertia) {
-		if (inertia < 0) {
-			throw new IllegalArgumentException("Inertia time must not be negative!");
-		}
-		this.inertia = inertia;
-	}
-
-	/**
-	 * Reset inertia time to value calculated automatically on the base of
-	 * interval. This value will be set to 2 * interval.
-	 */
-	public void clearInertia() {
-		this.inertia = -1;
-	}
-
-	/**
-	 * Get attached webcam object.
-	 *
-	 * @return Attached webcam
-	 */
-	public Webcam getWebcam() {
-		return webcam;
-	}
-
-	public boolean isMotion() {
-		if (!running.get()) {
-			LOG.warn("Motion cannot be detected when detector is not running!");
-		}
-		return motion;
-	}
-
-	/**
-	 * Get percentage fraction of image covered by motion. 0 means no motion on
-	 * image and 100 means full image covered by spontaneous motion.
-	 *
-	 * @return Return percentage image fraction covered by motion
-	 */
-	public double getMotionArea() {
-		return detectorAlgorithm.getArea();
-	}
-
-	/**
-	 * Get motion center of gravity. When no motion is detected this value
-	 * points to the image center.
-	 *
-	 * @return Center of gravity point
-	 */
-	public Point getMotionCog() {
-		Point cog = detectorAlgorithm.getCog();
-		if (cog == null) {
-			// detectorAlgorithm hasn't been called so far - get image center
-			int w = webcam.getViewSize().width;
-			int h = webcam.getViewSize().height;
-			cog = new Point(w / 2, h / 2);
-		}
-		return cog;
-	}
-
-	/**
-	 * @return the detectorAlgorithm
-	 */
-	public WebcamMotionDetectorAlgorithm getDetectorAlgorithm() {
-		return detectorAlgorithm;
-	}
-
-
-    public void setMaxMotionPoints(int i){
-        detectorAlgorithm.setMaxPoints(i);
+    if (!webcam.isOpen()) {
+      motion = false;
+      return;
     }
 
-    public int getMaxMotionPoints(){
-        return detectorAlgorithm.getMaxPoints();
+    BufferedImage currentOriginal = webcam.getImage();
+
+    if (currentOriginal == null) {
+      motion = false;
+      return;
     }
 
+    BufferedImage currentModified = detectorAlgorithm.prepareImage(currentOriginal);
 
-    public void setPointRange(int i){
-        detectorAlgorithm.setPointRange(i);
+    boolean movementDetected = detectorAlgorithm.detect(previousModified, currentModified);
+
+    if (movementDetected) {
+      motion = true;
+      lastMotionTimestamp = System.currentTimeMillis();
+      notifyMotionListeners(currentOriginal);
     }
 
-    public int getPointRange(){
-        return detectorAlgorithm.getPointRange();
+    previousOriginal = currentOriginal;
+    previousModified = currentModified;
+  }
+
+  /**
+   * Will notify all attached motion listeners.
+   * @param image with the motion detected
+   */
+  private void notifyMotionListeners(BufferedImage currentOriginal) {
+    WebcamMotionEvent wme = new WebcamMotionEvent(this, previousOriginal, currentOriginal, detectorAlgorithm.getArea(), detectorAlgorithm.getCog(), detectorAlgorithm.getPoints());
+    for (WebcamMotionListener l : listeners) {
+      try {
+        l.motionDetected(wme);
+      } catch (Exception e) {
+        WebcamExceptionHandler.handle(e);
+      }
     }
+  }
+
+  /**
+   * Add motion listener.
+   *
+   * @param l listener to add
+   * @return true if listeners list has been changed, false otherwise
+   */
+  public boolean addMotionListener(WebcamMotionListener l) {
+    return listeners.add(l);
+  }
+
+  /**
+   * @return All motion listeners as array
+   */
+  public WebcamMotionListener[] getMotionListeners() {
+    return listeners.toArray(new WebcamMotionListener[listeners.size()]);
+  }
+
+  /**
+   * Removes motion listener.
+   *
+   * @param l motion listener to remove
+   * @return true if listener was available on the list, false otherwise
+   */
+  public boolean removeMotionListener(WebcamMotionListener l) {
+    return listeners.remove(l);
+  }
+
+  /**
+   * @return Motion check interval in milliseconds
+   */
+  public int getInterval() {
+    return interval;
+  }
+
+  /**
+   * Motion check interval in milliseconds. After motion is detected, it's
+   * valid for time which is equal to value of 2 * interval.
+   *
+   * @param interval the new motion check interval (ms)
+   * @see #DEFAULT_INTERVAL
+   */
+  public void setInterval(int interval) {
+
+    if (interval < 100) {
+      throw new IllegalArgumentException("Motion check interval cannot be less than 100 ms");
+    }
+
+    this.interval = interval;
+  }
+
+  /**
+   * Sets pixelThreshold to the underlying detector algorithm, but only if the
+   * algorithm is (or extends) WebcamMotionDetectorDefaultAlgorithm
+   * 
+   * @see WebcamMotionDetectorDefaultAlgorithm#setPixelThreshold(int)
+   * 
+   * @param threshold the pixel intensity difference threshold
+   */
+  public void setPixelThreshold(int threshold) {
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
+      ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setPixelThreshold(threshold);
+    }
+  }
+
+  /**
+   * Sets areaThreshold to the underlying detector algorithm, but only if the
+   * algorithm is (or extends) WebcamMotionDetectorDefaultAlgorithm
+   * 
+   * @see WebcamMotionDetectorDefaultAlgorithm#setAreaThreshold(double)
+   * 
+   * @param threshold the percentage fraction of image area
+   */
+  public void setAreaThreshold(double threshold) {
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
+      ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setAreaThreshold(threshold);
+    }
+  }
+
+  /**
+   * Sets areaThresholdMAx to the underlying detector algorithm, but only if the
+   * algorithm is (or extends) WebcamMotionDetectorDefaultAlgorithm
+   * 
+   * @see WebcamMotionDetectorDefaultAlgorithm#setAreaThresholdMax(double)
+   * 
+   * @param threshold the percentage fraction of image area
+   */
+  public void setMaxAreaThreshold(double threshold) {
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
+      ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setMaxAreaThreshold(threshold);
+    }
+  }
+  
+  
+  public ArrayList<Integer> getThresholds() {
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
+      return ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).getThresholds();
+    } else {
+      throw new UnsupportedOperationException("This method is only valid for the default detector algorithm");
+    }
+  }
+
+  /**
+   * Set motion inertia (time when motion is valid). If no value specified
+   * this is set to 2 * interval. To reset to default value,
+   * {@link #clearInertia()} method must be used.
+   *
+   * @param inertia the motion inertia time in milliseconds
+   * @see #clearInertia()
+   */
+  public void setInertia(int inertia) {
+    if (inertia < 0) {
+      throw new IllegalArgumentException("Inertia time must not be negative!");
+    }
+    this.inertia = inertia;
+  }
+
+  /**
+   * Reset inertia time to value calculated automatically on the base of
+   * interval. This value will be set to 2 * interval.
+   */
+  public void clearInertia() {
+    this.inertia = -1;
+  }
+
+  /**
+   * Get attached webcam object.
+   *
+   * @return Attached webcam
+   */
+  public Webcam getWebcam() {
+    return webcam;
+  }
+
+  public boolean isMotion() {
+    if (!running.get()) {
+      LOG.warn("Motion cannot be detected when detector is not running!");
+    }
+    return motion;
+  }
+
+  /**
+   * Get percentage fraction of image covered by motion. 0 means no motion on
+   * image and 100 means full image covered by spontaneous motion.
+   *
+   * @return Return percentage image fraction covered by motion
+   */
+  public double getMotionArea() {
+    return detectorAlgorithm.getArea();
+  }
+
+  /**
+   * Get motion center of gravity. When no motion is detected this value
+   * points to the image center.
+   *
+   * @return Center of gravity point
+   */
+  public Point getMotionCog() {
+    Point cog = detectorAlgorithm.getCog();
+    if (cog == null) {
+      // detectorAlgorithm hasn't been called so far - get image center
+      int w = webcam.getViewSize().width;
+      int h = webcam.getViewSize().height;
+      cog = new Point(w / 2, h / 2);
+    }
+    return cog;
+  }
+
+  /**
+   * @return the detectorAlgorithm
+   */
+  public WebcamMotionDetectorAlgorithm getDetectorAlgorithm() {
+    return detectorAlgorithm;
+  }
+
+  public void setMaxMotionPoints(int i){
+    detectorAlgorithm.setMaxPoints(i);
+  }
+
+  public int getMaxMotionPoints(){
+    return detectorAlgorithm.getMaxPoints();
+  }
+
+  public void setPointRange(int i){
+    detectorAlgorithm.setPointRange(i);
+  }
+
+  public int getPointRange(){
+    return detectorAlgorithm.getPointRange();
+  }
 
 }

--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
@@ -1,6 +1,7 @@
 package com.github.sarxos.webcam;
 
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
@@ -375,6 +376,22 @@ public class WebcamMotionDetector {
   public void setMaxAreaThreshold(double threshold) {
     if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
       ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setMaxAreaThreshold(threshold);
+    } else {
+      throw new IllegalArgumentException("This algorithm does not support max threshold");
+    }
+  }
+  
+  
+  /**
+   * Set the "Do Not Engage" area of the frame. The "do not engage" area is an area
+   * of the frame where motion is ignored
+   * @param rectangle
+   */
+  public void setDne(Rectangle rectangle) {
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
+      ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setDne(rectangle);
+    } else {
+      throw new IllegalArgumentException("This algorithm does not support do not engage zone");
     }
   }
   

--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetector.java
@@ -346,8 +346,8 @@ public class WebcamMotionDetector {
    * @param threshold the pixel intensity difference threshold
    */
   public void setPixelThreshold(int threshold) {
-    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
-      ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setPixelThreshold(threshold);
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultWithDNE) {
+      ((WebcamMotionDetectorDefaultWithDNE)detectorAlgorithm).setPixelThreshold(threshold);
     }
   }
 
@@ -360,8 +360,8 @@ public class WebcamMotionDetector {
    * @param threshold the percentage fraction of image area
    */
   public void setAreaThreshold(double threshold) {
-    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
-      ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setAreaThreshold(threshold);
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultWithDNE) {
+      ((WebcamMotionDetectorDefaultWithDNE)detectorAlgorithm).setAreaThreshold(threshold);
     }
   }
 
@@ -374,8 +374,8 @@ public class WebcamMotionDetector {
    * @param threshold the percentage fraction of image area
    */
   public void setMaxAreaThreshold(double threshold) {
-    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultAlgorithm) {
-      ((WebcamMotionDetectorDefaultAlgorithm)detectorAlgorithm).setMaxAreaThreshold(threshold);
+    if (detectorAlgorithm instanceof WebcamMotionDetectorDefaultWithDNE) {
+      ((WebcamMotionDetectorDefaultWithDNE)detectorAlgorithm).setMaxAreaThreshold(threshold);
     } else {
       throw new IllegalArgumentException("This algorithm does not support max threshold");
     }

--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetectorDefaultAlgorithm.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetectorDefaultAlgorithm.java
@@ -10,283 +10,332 @@ import java.util.ArrayList;
 /**
  * Default motion detector algorithm.
  */
+/**
+ * @author kevin
+ *
+ */
 public class WebcamMotionDetectorDefaultAlgorithm implements WebcamMotionDetectorAlgorithm {
 
-	/**
-	 * Default pixel difference intensity threshold (set to 25).
-	 */
-	public static final int DEFAULT_PIXEL_THREASHOLD = 25;
+  /**
+   * Default pixel difference intensity threshold (set to 25).
+   */
+  public static final int DEFAULT_PIXEL_THREASHOLD = 25;
 
-	/**
-	 * Default percentage image area fraction threshold (set to 0.2%).
-	 */
-	public static final double DEFAULT_AREA_THREASHOLD = 0.2;
-	
-	/**
-	 * Pixel intensity threshold (0 - 255).
-	 */
-	private volatile int pixelThreshold = DEFAULT_PIXEL_THREASHOLD;
+  /**
+   * Default percentage image area fraction threshold (set to 0.2%).
+   */
+  public static final double DEFAULT_AREA_THREASHOLD = 0.2;
 
-	/**
-	 * Pixel intensity threshold (0 - 100).
-	 */
-	private volatile double areaThreshold = DEFAULT_AREA_THREASHOLD;
+  /**
+   * Default max percentage image area fraction threshold (set to 50%).
+   */
+  public static final double DEFAULT_AREA_THREASHOLD_MAX = 100;
 
-	/**
-	 * Motion strength (0 = no motion, 100 = full image covered by motion).
-	 */
-	private double area = 0;
+  /**
+   * Pixel intensity threshold (0 - 255).
+   */
+  private volatile int pixelThreshold = DEFAULT_PIXEL_THREASHOLD;
 
-	/**
-	 * Center of motion gravity.
-	 */
-	private Point cog = null;
-	
-	/**
-	 * Blur filter instance.
-	 */
-	private final JHBlurFilter blur = new JHBlurFilter(6, 6, 1);
+  /**
+   * Minimum pixel change percentage threshold (0 - 100).
+   */
+  private volatile double areaThreshold = DEFAULT_AREA_THREASHOLD;
 
-	/**
-	 * Gray filter instance.
-	 */
-	private final JHGrayFilter gray = new JHGrayFilter();
-	
-	/**
-	 * Creates default motion detector algorithm.
-	 * 
-	 * @param pixelThreshold intensity threshold (0 - 255)
-	 * @param areaThreshold percentage threshold of image covered by motion
-	 */
-	public WebcamMotionDetectorDefaultAlgorithm(int pixelThreshold, double areaThreshold) {
-		setPixelThreshold(pixelThreshold);
-		setAreaThreshold(areaThreshold);
-	}
+  /**
+   * Maximum pixel change percentage threshold (0 - 100).
+   */
+  private volatile double areaThresholdMax = DEFAULT_AREA_THREASHOLD_MAX;
 
-	@Override
-	public BufferedImage prepareImage(BufferedImage original) {
-		BufferedImage modified = blur.filter(original, null);
-		modified = gray.filter(modified, null);
-		return modified;
-	}
+  /**
+   * Motion strength (0 = no motion, 100 = full image covered by motion).
+   */
+  private double area = 0;
 
-	@Override
-	public boolean detect(BufferedImage previousModified, BufferedImage currentModified) {
-        points.clear();
-		int p = 0;
+  /**
+   * Center of motion gravity.
+   */
+  private Point cog = null;
 
-		int cogX = 0;
-		int cogY = 0;
+  /**
+   * Blur filter instance.
+   */
+  private final JHBlurFilter blur = new JHBlurFilter(6, 6, 1);
 
-		int w = currentModified.getWidth();
-		int h = currentModified.getHeight();
+  /**
+   * Gray filter instance.
+   */
+  private final JHGrayFilter gray = new JHGrayFilter();
 
-        int j = 0;
-		if (previousModified != null) {
-			for (int x = 0; x < w; x++) {
-				for (int y = 0; y < h; y++) {
+  /**
+   * Creates default motion detector algorithm.
+   * 
+   * @param pixelThreshold intensity threshold (0 - 255)
+   * @param areaThreshold percentage threshold of image covered by motion
+   */
+  public WebcamMotionDetectorDefaultAlgorithm(int pixelThreshold, double areaThreshold) {
+    setPixelThreshold(pixelThreshold);
+    setAreaThreshold(areaThreshold);
+  }
 
-					int cpx = currentModified.getRGB(x, y);
-					int ppx = previousModified.getRGB(x, y);
-					int pid = combinePixels(cpx, ppx) & 0x000000ff;
+  @Override
+  public BufferedImage prepareImage(BufferedImage original) {
+    BufferedImage modified = blur.filter(original, null);
+    modified = gray.filter(modified, null);
+    return modified;
+  }
 
-					if (pid >= pixelThreshold) {
-                        Point pp = new Point(x, y);
-                        boolean keep = j < maxPoints;
+  @Override
+  public boolean detect(BufferedImage previousModified, BufferedImage currentModified) {
+    points.clear();
+    thresholds.clear();
+    int p = 0;
 
-                        if (keep) {
-                            for (Point g : points) {
-                                if (g.x != pp.x || g.y != pp.y) {
-                                    if (pp.distance(g) <= range) {
-                                        keep = false;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
+    int cogX = 0;
+    int cogY = 0;
 
-                        if (keep) {
-                            points.add(new Point(x, y));
-                            j += 1;
-                        }
+    int w = currentModified.getWidth();
+    int h = currentModified.getHeight();
 
-                        cogX += x;
-                        cogY += y;
-                        p += 1;
-                    }
-				}
-			}
-		}
+    int j = 0;
+    if (previousModified != null) {
+      for (int x = 0; x < w; x++) {
+        for (int y = 0; y < h; y++) {
 
-		area = p * 100d / (w * h);
-		
-		if (area >= areaThreshold) {
-			cog = new Point(cogX / p, cogY / p);
-			return true;
-		} else {
-			cog = new Point(w / 2, h / 2);
-			return false;
-		}
-	}
+          int cpx = currentModified.getRGB(x, y);
+          int ppx = previousModified.getRGB(x, y);
+          int pid = combinePixels(cpx, ppx) & 0x000000ff;
 
-	@Override
-	public Point getCog() {
-		return this.cog;
-	}
+          if (pid >= pixelThreshold) {
+            Point pp = new Point(x, y);
+            boolean keep = j < maxPoints;
 
-	@Override
-	public double getArea() {
-		return this.area;
-	}
-	
-	/**
-	 * Set pixel intensity difference threshold above which pixel is classified
-	 * as "moved". Minimum value is 0 and maximum is 255. Default value is 10.
-	 * This value is equal for all RGB components difference.
-	 *
-	 * @param threshold the pixel intensity difference threshold
-	 * @see #DEFAULT_PIXEL_THREASHOLD
-	 */
-	public void setPixelThreshold(int threshold) {
-		if (threshold < 0) {
-			throw new IllegalArgumentException("Pixel intensity threshold cannot be negative!");
-		}
-		if (threshold > 255) {
-			throw new IllegalArgumentException("Pixel intensity threshold cannot be higher than 255!");
-		}
-		this.pixelThreshold = threshold;
-	}
+            if (keep) {
+              for (Point g : points) {
+                if (g.x != pp.x || g.y != pp.y) {
+                  if (pp.distance(g) <= range) {
+                    keep = false;
+                    break;
+                  }
+                }
+              }
+            }
 
-	/**
-	 * Set percentage fraction of detected motion area threshold above which it
-	 * is classified as "moved". Minimum value for this is 0 and maximum is 100,
-	 * which corresponds to full image covered by spontaneous motion.
-	 *
-	 * @param threshold the percentage fraction of image area
-	 * @see #DEFAULT_AREA_THREASHOLD
-	 */
-	public void setAreaThreshold(double threshold) {
-		if (threshold < 0) {
-			throw new IllegalArgumentException("Area fraction threshold cannot be negative!");
-		}
-		if (threshold > 100) {
-			throw new IllegalArgumentException("Area fraction threshold cannot be higher than 100!");
-		}
-		this.areaThreshold = threshold;
-	}
-	
-	private static int combinePixels(int rgb1, int rgb2) {
+            if (keep) {
+              points.add(new Point(x, y));
+              j += 1;
+            }
 
-		// first ARGB
-
-		int a1 = (rgb1 >> 24) & 0xff;
-		int r1 = (rgb1 >> 16) & 0xff;
-		int g1 = (rgb1 >> 8) & 0xff;
-		int b1 = rgb1 & 0xff;
-
-		// second ARGB
-
-		int a2 = (rgb2 >> 24) & 0xff;
-		int r2 = (rgb2 >> 16) & 0xff;
-		int g2 = (rgb2 >> 8) & 0xff;
-		int b2 = rgb2 & 0xff;
-
-		r1 = clamp(Math.abs(r1 - r2));
-		g1 = clamp(Math.abs(g1 - g2));
-		b1 = clamp(Math.abs(b1 - b2));
-
-		// in case if alpha is enabled (translucent image)
-
-		if (a1 != 0xff) {
-			a1 = a1 * 0xff / 255;
-			int a3 = (255 - a1) * a2 / 255;
-			r1 = clamp((r1 * a1 + r2 * a3) / 255);
-			g1 = clamp((g1 * a1 + g2 * a3) / 255);
-			b1 = clamp((b1 * a1 + b2 * a3) / 255);
-			a1 = clamp(a1 + a3);
-		}
-
-		return (a1 << 24) | (r1 << 16) | (g1 << 8) | b1;
-	}
-
-	/**
-	 * Clamp a value to the range 0..255
-	 */
-	private static int clamp(int c) {
-		if (c < 0) {
-			return 0;
-		}
-		if (c > 255) {
-			return 255;
-		}
-		return c;
-	}
-
-
-    /**
-     * ArrayList to store the points for a detected motion
-     */
-    ArrayList<Point> points = new ArrayList<Point>();
-
-    /**
-     * The default minimum range between each point where motion has been detected
-     */
-    public static final int DEFAULT_RANGE = 50;
-
-    /**
-     * The default for the max amount of points that can be detected at one time
-     */
-    public static final int DEFAULT_MAX_POINTS = 100;
-
-    /**
-     * The current minimum range between points
-     */
-    private int range = DEFAULT_RANGE;
-
-    /**
-     * The current max amount of points
-     */
-    private int maxPoints = DEFAULT_MAX_POINTS;
-
-    /**
-     * Set the minimum range between each point detected
-     * @param i the range to set
-     */
-    public void setPointRange(int i){
-        range = i;
+            cogX += x;
+            cogY += y;
+            p += 1;
+            thresholds.add(pid);
+          }
+        }
+      }
     }
 
-    /**
-     * Get the current minimum range between each point
-     * @return The current range
-     */
-    public int getPointRange(){
-        return range;
+    area = p * 100d / (w * h);
+
+    if (area >= areaThreshold &&
+        area <= areaThresholdMax)
+    {
+      cog = new Point(cogX / p, cogY / p);
+      return true;
+    }
+    else
+    {
+      cog = new Point(w / 2, h / 2);
+      return false;
+    }
+  }
+
+  @Override
+  public Point getCog() {
+    return this.cog;
+  }
+
+  @Override
+  public double getArea() {
+    return this.area;
+  }
+
+  /**
+   * Set pixel intensity difference threshold above which pixel is classified
+   * as "moved". Minimum value is 0 and maximum is 255. Default value is 10.
+   * This value is equal for all RGB components difference.
+   *
+   * @param threshold the pixel intensity difference threshold
+   * @see #DEFAULT_PIXEL_THREASHOLD
+   */
+  public void setPixelThreshold(int threshold) {
+    if (threshold < 0) {
+      throw new IllegalArgumentException("Pixel intensity threshold cannot be negative!");
+    }
+    if (threshold > 255) {
+      throw new IllegalArgumentException("Pixel intensity threshold cannot be higher than 255!");
+    }
+    this.pixelThreshold = threshold;
+  }
+
+  /**
+   * Set percentage fraction of detected motion area threshold above which it
+   * is classified as "moved". Minimum value for this is 0 and maximum is 100,
+   * which corresponds to full image covered by spontaneous motion.
+   *
+   * @param threshold the percentage fraction of image area
+   * @see #DEFAULT_AREA_THREASHOLD
+   */
+  public void setAreaThreshold(double threshold) {
+    if (threshold < 0) {
+      throw new IllegalArgumentException("Area fraction threshold cannot be negative!");
+    }
+    if (threshold > 100) {
+      throw new IllegalArgumentException("Area fraction threshold cannot be higher than 100!");
+    }
+    this.areaThreshold = threshold;
+  }
+
+  /**
+   * Set max percentage fraction of detected motion area threshold, below which
+   * it is classified as "moved". The max is optionally used to help filter
+   * false positives caused by sudden exposure changes. Minimum value for this
+   * is 0 and maximum is 100, which corresponds to full image covered by
+   * spontaneous motion.
+   *
+   * @param threshold
+   *          the percentage fraction of image area
+   * @see #DEFAULT_AREA_THREASHOLD_MAX
+   */
+  public void setMaxAreaThreshold(double threshold) {
+    if (threshold < 0) {
+      throw new IllegalArgumentException("Area fraction threshold cannot be negative!");
+    }
+    if (threshold > 100) {
+      throw new IllegalArgumentException("Area fraction threshold cannot be higher than 100!");
+    }
+    this.areaThresholdMax = threshold;
+  }
+
+  private static int combinePixels(int rgb1, int rgb2) {
+
+    // first ARGB
+
+    int a1 = (rgb1 >> 24) & 0xff;
+    int r1 = (rgb1 >> 16) & 0xff;
+    int g1 = (rgb1 >> 8) & 0xff;
+    int b1 = rgb1 & 0xff;
+
+    // second ARGB
+
+    int a2 = (rgb2 >> 24) & 0xff;
+    int r2 = (rgb2 >> 16) & 0xff;
+    int g2 = (rgb2 >> 8) & 0xff;
+    int b2 = rgb2 & 0xff;
+
+    r1 = clamp(Math.abs(r1 - r2));
+    g1 = clamp(Math.abs(g1 - g2));
+    b1 = clamp(Math.abs(b1 - b2));
+
+    // in case if alpha is enabled (translucent image)
+
+    if (a1 != 0xff) {
+      a1 = a1 * 0xff / 255;
+      int a3 = (255 - a1) * a2 / 255;
+      r1 = clamp((r1 * a1 + r2 * a3) / 255);
+      g1 = clamp((g1 * a1 + g2 * a3) / 255);
+      b1 = clamp((b1 * a1 + b2 * a3) / 255);
+      a1 = clamp(a1 + a3);
     }
 
+    return (a1 << 24) | (r1 << 16) | (g1 << 8) | b1;
+  }
 
-    /**
-     * Set the max amount of points that can be detected at one time
-     * @param i The amount of points that can be detected
-     */
-    public void setMaxPoints(int i){
-        maxPoints = i;
+  /**
+   * Clamp a value to the range 0..255
+   */
+  private static int clamp(int c) {
+    if (c < 0) {
+      return 0;
     }
-
-
-    /**
-     * Get the current max amount of points that can be detected at one time
-     * @return
-     */
-    public int getMaxPoints(){
-        return maxPoints;
+    if (c > 255) {
+      return 255;
     }
+    return c;
+  }
 
-    /**
-     * Returns the currently stored points that have been detected
-     * @return The current points
-     */
-    public ArrayList<Point> getPoints(){
-        return points;
-    }
+
+  /**
+   * ArrayList to store the points for a detected motion
+   */
+  ArrayList<Point> points = new ArrayList<Point>();
+  
+  /**
+   * Array list to store thresholds for debugging 
+   */
+  ArrayList<Integer> thresholds = new ArrayList<Integer>();
+
+  public ArrayList<Integer> getThresholds() {
+    return this.thresholds;
+  }
+  /**
+   * The default minimum range between each point where motion has been detected
+   */
+  public static final int DEFAULT_RANGE = 50;
+
+  /**
+   * The default for the max amount of points that can be detected at one time
+   */
+  public static final int DEFAULT_MAX_POINTS = 100;
+
+  /**
+   * The current minimum range between points
+   */
+  private int range = DEFAULT_RANGE;
+
+  /**
+   * The current max amount of points
+   */
+  private int maxPoints = DEFAULT_MAX_POINTS;
+
+  /**
+   * Set the minimum range between each point detected
+   * @param i the range to set
+   */
+  public void setPointRange(int i){
+    range = i;
+  }
+
+  /**
+   * Get the current minimum range between each point
+   * @return The current range
+   */
+  public int getPointRange(){
+    return range;
+  }
+
+
+  /**
+   * Set the max amount of points that can be detected at one time
+   * @param i The amount of points that can be detected
+   */
+  public void setMaxPoints(int i){
+    maxPoints = i;
+  }
+
+
+  /**
+   * Get the current max amount of points that can be detected at one time
+   * @return
+   */
+  public int getMaxPoints(){
+    return maxPoints;
+  }
+
+  /**
+   * Returns the currently stored points that have been detected
+   * @return The current points
+   */
+  public ArrayList<Point> getPoints(){
+    return points;
+  }
 }


### PR DESCRIPTION
I have a camera fixed outside watching an area of my house. It's been using this webcam-capture library for almost two years. Its been great! I noticed that when clouds pass in front of the sun it would cause the aperture of the webcam to open. Then when the clouds passed the camera would be flooded with light for one or two frames while the exposure adjusted to the light, which triggered a motion event. I was able to to mostly negate the problem by setting a fixed exposure value so that the exposure wouldn't change so much when the environmental light changes. However, it gave me the idea to implement a max threshold feature in the motion sensor algorithm so that sudden "white outs" caused by exposure would not trigger a motion event. The default max threshold is set to 100, effectively removing the limit. An accessor method has been added to allow the user to adjust the value.
![visitor20160816-133026](https://cloud.githubusercontent.com/assets/2906785/22312583/0b582dee-e31e-11e6-92d2-1e66d87d57b3.jpg)
![visitor20160816-131820](https://cloud.githubusercontent.com/assets/2906785/22312579/07382944-e31e-11e6-9e9a-fc2edd22ebbe.jpg)

Another challenge I encountered having a motion detection camera deployed is the hanging flower seen in the upper right of the image below. When the wind blows and the plant swings it would trigger a motion event (rightfully so). It gave me the idea to add a "Do Not Engage" feature to the algorithm. The "Do No Engage" feature is simply a rectangle specified by the user in which the algorithm will ignore motion. The feature is implemented by allowing the user to pass a `Rectangle` into the algorithm, and then the algorithm only processes pixels that are not contained in the `Rectangle`. 

![visitor20160601-154220](https://cloud.githubusercontent.com/assets/2906785/22312250/b8089efe-e31c-11e6-8f92-4e0e2e220f03.jpg)