### PR TITLE
Fix copy-and-paste typo in javadoc

### DIFF
--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetectorDefaultAlgorithm.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/WebcamMotionDetectorDefaultAlgorithm.java
@@ -28,7 +28,7 @@ public class WebcamMotionDetectorDefaultAlgorithm implements WebcamMotionDetecto
 	private volatile int pixelThreshold = DEFAULT_PIXEL_THREASHOLD;
 
 	/**
-	 * Pixel intensity threshold (0 - 100).
+	 * Percentage image area fraction threshold (0 - 100).
 	 */
 	private volatile double areaThreshold = DEFAULT_AREA_THREASHOLD;
 


### PR DESCRIPTION
Just was going through and saw that the javadoc was copied and pasted to the next field without being edited to be correct. Simple change.