### PR TITLE
Support Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,24 +66,24 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.2</version>
+        <version>1.7.26</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.0.9</version>
+        <version>1.2.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.jayway.awaitility</groupId>
         <artifactId>awaitility</artifactId>
-        <version>1.6.2</version>
+        <version>1.7.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -95,19 +95,19 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.2</version>
+        <version>4.0.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-easymock</artifactId>
-        <version>1.5.5</version>
+        <version>2.0.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
-        <version>1.5.5</version>
+        <version>2.0.2</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -155,9 +155,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M3</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -250,7 +255,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>2.4</version>
             <executions>
               <execution>
                 <id>copy-dependencies</id>

--- a/webcam-capture-drivers/driver-ffmpeg-cli/pom.xml
+++ b/webcam-capture-drivers/driver-ffmpeg-cli/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.9</version>
+      <version>1.2.3</version>
     </dependency>
     <dependency>
       <groupId>com.github.sarxos</groupId>

--- a/webcam-capture-drivers/driver-gst1/pom.xml
+++ b/webcam-capture-drivers/driver-gst1/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>4.2.2</version>
+      <version>5.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.freedesktop.gstreamer</groupId>

--- a/webcam-capture-drivers/driver-ipcam/pom.xml
+++ b/webcam-capture-drivers/driver-ipcam/pom.xml
@@ -30,14 +30,19 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.3</version>
+      <version>4.5.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <version>4.5.3</version>
+      <version>4.5.9</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -51,7 +56,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>4.2.0</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/webcam-capture-drivers/driver-raspberrypi/pom.xml
+++ b/webcam-capture-drivers/driver-raspberrypi/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -65,27 +65,23 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
         <configuration>
           <!-- <compilerArgument>-g:none</compilerArgument> -->
           <debug>true</debug>
-          <target>1.8</target>
-          <source>1.8</source>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
-        <version>2.9</version>
         <configuration>
           <downloadSources>true</downloadSources>
           <downloadJavadocs>false</downloadJavadocs>
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
             <goals>

--- a/webcam-capture-drivers/driver-vlcj/pom.xml
+++ b/webcam-capture-drivers/driver-vlcj/pom.xml
@@ -64,7 +64,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>4.2.0</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/webcam-capture-examples/webcam-capture-akka/pom.xml
+++ b/webcam-capture-examples/webcam-capture-akka/pom.xml
@@ -16,52 +16,52 @@
     <dependency>
       <groupId>com.github.sarxos</groupId>
       <artifactId>webcam-capture</artifactId>
-      <version>0.3.11</version>
+      <version>0.3.12</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-actor_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.23</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-cluster-sharding_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.23</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-cluster-tools_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.23</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-cluster_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.23</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-distributed-data-experimental_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>2.4.20</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-persistence_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.23</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-slf4j_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.23</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-slf4j_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.23</version>
     </dependency>
     <dependency>
       <groupId>io.javaslang</groupId>
       <artifactId>javaslang</artifactId>
-      <version>2.0.2</version>
+      <version>2.0.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/webcam-capture-examples/webcam-capture-javafx-fxml/pom.xml
+++ b/webcam-capture-examples/webcam-capture-javafx-fxml/pom.xml
@@ -22,48 +22,21 @@
       <artifactId>webcam-capture</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>12.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-swing</artifactId>
+      <version>12.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-fxml</artifactId>
+      <version>12.0.1</version>
+    </dependency>
   </dependencies>
 
-  <build>
-    <finalName>WebCamAppLauncher</finalName>
-    <plugins>
-      <plugin>
-        <groupId>com.zenjava</groupId>
-        <artifactId>javafx-maven-plugin</artifactId>
-        <version>8.1.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <mainClass>WebCamAppLauncher</mainClass>
-          <bundleArguments>
-            <!-- just to w/a https://github.com/zonski/javafx-maven-plugin/pull/72 -->
-          </bundleArguments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
-  <profiles>
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>1.7</jdk>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.oracle</groupId>
-          <artifactId>javafx</artifactId>
-          <version>2.2</version>
-          <scope>system</scope>
-          <systemPath>${java.home}/lib/jfxrt.jar</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/webcam-capture-examples/webcam-capture-javafx-fxml/src/main/java/com/github/sarxos/webcam/WebCamAppLauncher.java
+++ b/webcam-capture-examples/webcam-capture-javafx-fxml/src/main/java/com/github/sarxos/webcam/WebCamAppLauncher.java
@@ -1,3 +1,5 @@
+package com.github.sarxos.webcam;
+
 import java.io.IOException;
 
 import javafx.application.Application;

--- a/webcam-capture-examples/webcam-capture-javafx-fxml/src/main/java/com/github/sarxos/webcam/WebCamPreviewController.java
+++ b/webcam-capture-examples/webcam-capture-javafx-fxml/src/main/java/com/github/sarxos/webcam/WebCamPreviewController.java
@@ -1,3 +1,5 @@
+package com.github.sarxos.webcam;
+
 import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.util.ResourceBundle;
@@ -20,8 +22,6 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
-
-import com.github.sarxos.webcam.Webcam;
 
 
 /**

--- a/webcam-capture-examples/webcam-capture-javafx-service/pom.xml
+++ b/webcam-capture-examples/webcam-capture-javafx-service/pom.xml
@@ -8,11 +8,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/webcam-capture-examples/webcam-capture-javafx/pom.xml
+++ b/webcam-capture-examples/webcam-capture-javafx/pom.xml
@@ -22,57 +22,16 @@
       <artifactId>webcam-capture</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>12.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-swing</artifactId>
+      <version>12.0.1</version>
+    </dependency>
   </dependencies>
 
-  <build>
-    <finalName>WebCamAppLauncher</finalName>
-    <plugins>
-      <plugin>
-        <groupId>com.zenjava</groupId>
-        <artifactId>javafx-maven-plugin</artifactId>
-        <version>8.1.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <mainClass>WebCamAppLauncher</mainClass>
-          <bundleArguments>
-            <!-- just to w/a https://github.com/zonski/javafx-maven-plugin/pull/72 -->
-          </bundleArguments>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
-  <profiles>
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>1.7</jdk>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.oracle</groupId>
-          <artifactId>javafx</artifactId>
-          <version>2.2</version>
-          <scope>system</scope>
-          <systemPath>${java.home}/lib/jfxrt.jar</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/webcam-capture-examples/webcam-capture-javafx/src/main/java/com/github/sarxos/webcam/WebCamAppLauncher.java
+++ b/webcam-capture-examples/webcam-capture-javafx/src/main/java/com/github/sarxos/webcam/WebCamAppLauncher.java
@@ -1,7 +1,7 @@
+package com.github.sarxos.webcam;
+
 import java.awt.image.BufferedImage;
 import java.util.concurrent.atomic.AtomicReference;
-
-import com.github.sarxos.webcam.Webcam;
 
 import javafx.application.Application;
 import javafx.application.Platform;

--- a/webcam-capture-examples/webcam-capture-live-streaming/pom.xml
+++ b/webcam-capture-examples/webcam-capture-live-streaming/pom.xml
@@ -36,17 +36,17 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
-      <version>3.6.3.Final</version>
+      <version>3.10.6.Final</version>
     </dependency>
     <dependency>
       <groupId>net.coobird</groupId>
       <artifactId>thumbnailator</artifactId>
-      <version>0.4.3</version>
+      <version>0.4.8</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.3</version>
+      <version>1.7.26</version>
     </dependency>
     <dependency>
       <groupId>xuggle</groupId>

--- a/webcam-capture-examples/webcam-capture-painter/pom.xml
+++ b/webcam-capture-examples/webcam-capture-painter/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.github.insubstantial</groupId>
       <artifactId>substance</artifactId>
-      <version>7.1</version>
+      <version>7.3</version>
     </dependency>
     <dependency>
       <groupId>com.github.sarxos</groupId>

--- a/webcam-capture-examples/webcam-capture-qrcode/pom.xml
+++ b/webcam-capture-examples/webcam-capture-qrcode/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.google.zxing</groupId>
       <artifactId>javase</artifactId>
-      <version>3.3.0</version>
+      <version>3.4.0</version>
     </dependency>
   </dependencies>
 

--- a/webcam-capture-examples/webcam-capture-swt-awt/pom.xml
+++ b/webcam-capture-examples/webcam-capture-swt-awt/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.eclipse.swt</groupId>
       <artifactId>${swt.artifactId}</artifactId>
-      <version>4.2.1</version>
+      <version>4.6.1</version>
     </dependency>
   </dependencies>
 

--- a/webcam-capture-examples/webcam-capture-websockets/pom.xml
+++ b/webcam-capture-examples/webcam-capture-websockets/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.5.1</version>
+      <version>2.9.9.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.sarxos</groupId>
@@ -27,14 +27,19 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
-      <version>9.2.7.v20150116</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.2</version>
+      <version>1.7.26</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-server</artifactId>
+      <version>9.4.19.v20190610</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/webcam-capture/pom.xml
+++ b/webcam-capture/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>4.2.0</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>


### PR DESCRIPTION
1) Added `<artifactId>jaxb-api</artifactId>` to webcam-capture-driver-ipcam dependencies (see: https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist)

2) Added `<artifactId>maven-surefire-plugin</artifactId>` to webcam-capture-parent plugins since `<groupId>org.apache.felix</groupId> <artifactId>maven-bundle-plugin</artifactId>` was packed with an unsupported version for Java 11. `mvn test` now works almost smoothly (see 3th steps)...

3) Upgraded all unit test dependencies: some of them were crashing on Java 11. Upgrade them resolve the problem. I did not investigate more. (thanks to `mvn versions:display-dependency-updates`)