### PR TITLE
Exclude unused transitive dependency

### DIFF
--- a/webcam-capture-drivers/driver-openimaj/pom.xml
+++ b/webcam-capture-drivers/driver-openimaj/pom.xml
@@ -25,6 +25,12 @@
       <groupId>com.nativelibs4java</groupId>
       <artifactId>bridj</artifactId>
       <version>0.7.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.android.tools</groupId>
+          <artifactId>dx</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.openimaj</groupId>


### PR DESCRIPTION
Hello, I noticed that the transitive dependency `com.google.android.tools:dx` can be safely excluded from direct dependency `com.nativelibs4java:bridj`  in module `webcam-capture-driver-openimaj`. This makes the dependency tree of the module slimmer.