### PR TITLE
Remove redundant initialization

### DIFF
--- a/webcam-capture/src/example/java/CalculateFPSExample.java
+++ b/webcam-capture/src/example/java/CalculateFPSExample.java
@@ -6,8 +6,8 @@ public class CalculateFPSExample {
 
 	public static void main(String[] args) {
 
-		long t1 = 0;
-		long t2 = 0;
+		long t1;
+		long t2;
 
 		int p = 10;
 		int r = 5;


### PR DESCRIPTION
Remove redundant initialization. We don't need to initialize t1 and t2 to a value since below k and p are explicitly defined in for loop and there's no other implicit conditions that may cause an runtime error if t1 and t2 are not initialized