### PR TITLE
Test improvement

### DIFF
--- a/webcam-capture/src/test/java/com/github/sarxos/webcam/WebcamPanelTest.java
+++ b/webcam-capture/src/test/java/com/github/sarxos/webcam/WebcamPanelTest.java
@@ -12,8 +12,8 @@ import com.github.sarxos.webcam.ds.test.DummyDriver;
 
 public class WebcamPanelTest {
 
-	private final int width = 256;
-	private final int height = 345;
+	private final int WIDTH = 256;
+	private final int HEIGHT = 345;
 
 	@Test
 	public void test_size() throws InterruptedException {
@@ -46,7 +46,7 @@ public class WebcamPanelTest {
 		Webcam.setDriver(new DummyDriver());
 
 		final Webcam w = Webcam.getDefault();
-		final WebcamPanel p = new WebcamPanel(w, new Dimension(width, height), false);
+		final WebcamPanel p = new WebcamPanel(w, new Dimension(WIDTH, HEIGHT), false);
 
 		w.open();
 		p.repaint();
@@ -55,10 +55,10 @@ public class WebcamPanelTest {
 
 		Assertions
 			.assertThat(d.getWidth())
-			.isEqualTo(width);
+			.isEqualTo(WIDTH);
 		Assertions
 			.assertThat(d.getHeight())
-			.isEqualTo(height);
+			.isEqualTo(HEIGHT);
 
 		p.stop();
 		w.close();
@@ -72,7 +72,7 @@ public class WebcamPanelTest {
 		final Webcam w = Webcam.getDefault();
 		w.open();
 
-		final WebcamPanel p = new WebcamPanel(w, new Dimension(width, height), false);
+		final WebcamPanel p = new WebcamPanel(w, new Dimension(WIDTH, HEIGHT), false);
 		p.setDrawMode(DrawMode.FILL);
 		p.start();
 
@@ -96,7 +96,7 @@ public class WebcamPanelTest {
 		final Webcam w = Webcam.getDefault();
 		w.open();
 
-		final WebcamPanel p = new WebcamPanel(w, new Dimension(width, height), false);
+		final WebcamPanel p = new WebcamPanel(w, new Dimension(WIDTH, HEIGHT), false);
 		p.setDrawMode(DrawMode.FIT);
 		p.start();
 
@@ -120,7 +120,7 @@ public class WebcamPanelTest {
 		final Webcam w = Webcam.getDefault();
 		w.open();
 
-		final WebcamPanel p = new WebcamPanel(w, new Dimension(width, height), false);
+		final WebcamPanel p = new WebcamPanel(w, new Dimension(WIDTH, HEIGHT), false);
 		p.setDrawMode(DrawMode.NONE);
 		p.start();
 

--- a/webcam-capture/src/test/java/com/github/sarxos/webcam/WebcamPanelTest.java
+++ b/webcam-capture/src/test/java/com/github/sarxos/webcam/WebcamPanelTest.java
@@ -12,6 +12,9 @@ import com.github.sarxos.webcam.ds.test.DummyDriver;
 
 public class WebcamPanelTest {
 
+	private final int width = 256;
+	private final int height = 345;
+
 	@Test
 	public void test_size() throws InterruptedException {
 
@@ -43,7 +46,7 @@ public class WebcamPanelTest {
 		Webcam.setDriver(new DummyDriver());
 
 		final Webcam w = Webcam.getDefault();
-		final WebcamPanel p = new WebcamPanel(w, new Dimension(256, 345), false);
+		final WebcamPanel p = new WebcamPanel(w, new Dimension(width, height), false);
 
 		w.open();
 		p.repaint();
@@ -52,10 +55,10 @@ public class WebcamPanelTest {
 
 		Assertions
 			.assertThat(d.getWidth())
-			.isEqualTo(256);
+			.isEqualTo(width);
 		Assertions
 			.assertThat(d.getHeight())
-			.isEqualTo(345);
+			.isEqualTo(height);
 
 		p.stop();
 		w.close();
@@ -69,7 +72,7 @@ public class WebcamPanelTest {
 		final Webcam w = Webcam.getDefault();
 		w.open();
 
-		final WebcamPanel p = new WebcamPanel(w, new Dimension(256, 345), false);
+		final WebcamPanel p = new WebcamPanel(w, new Dimension(width, height), false);
 		p.setDrawMode(DrawMode.FILL);
 		p.start();
 
@@ -93,7 +96,7 @@ public class WebcamPanelTest {
 		final Webcam w = Webcam.getDefault();
 		w.open();
 
-		final WebcamPanel p = new WebcamPanel(w, new Dimension(256, 345), false);
+		final WebcamPanel p = new WebcamPanel(w, new Dimension(width, height), false);
 		p.setDrawMode(DrawMode.FIT);
 		p.start();
 
@@ -117,7 +120,7 @@ public class WebcamPanelTest {
 		final Webcam w = Webcam.getDefault();
 		w.open();
 
-		final WebcamPanel p = new WebcamPanel(w, new Dimension(256, 345), false);
+		final WebcamPanel p = new WebcamPanel(w, new Dimension(width, height), false);
 		p.setDrawMode(DrawMode.NONE);
 		p.start();
 


### PR DESCRIPTION
This is a test refactoring

**Problem:**
The Magic Number Test occurs when assert() statements in a test method contain numeric literals (i.e., magic numbers) as parameters.

**Solution:**
As magic numbers do not indicate the meaning/purpose of the number, they should be replaced with constants or variables, thereby providing a descriptive name for the input.

**Result:**
- Before:
Assertions
	.assertThat(d.getWidth())
	.isEqualTo(256);
Assertions
	.assertThat(d.getHeight())
	.isEqualTo(345);
- After:
private final int WIDTH= 256;
private final int HEIGTH = 345;
Assertions
	.assertThat(d.getWidth())
	.isEqualTo(WIDTH);
Assertions
	.assertThat(d.getHeight())
	.isEqualTo(HEIGHT);