### PR TITLE
Could com.github.sarxos:webcam-capture-example-video-recordig-humble:0.3.13-SNAPSHOT drop off redundant dependencies to loose weight? 

### DIFF
--- a/webcam-capture-examples/webcam-capture-video-recording-humble/pom.xml
+++ b/webcam-capture-examples/webcam-capture-video-recording-humble/pom.xml
@@ -30,6 +30,32 @@
       <groupId>io.humble</groupId>
       <artifactId>humble-video-all</artifactId>
       <version>0.2.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.humble</groupId>
+          <artifactId>humble-video-arch-x86_64-w64-mingw32</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.humble</groupId>
+          <artifactId>humble-video-arch-i686-apple-darwin12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.humble</groupId>
+          <artifactId>humble-video-arch-i686-pc-linux-gnu6</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.humble</groupId>
+          <artifactId>humble-video-arch-x86_64-pc-linux-gnu6</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.humble</groupId>
+          <artifactId>humble-video-arch-i686-w64-mingw32</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.humble</groupId>
+          <artifactId>humble-video-arch-x86_64-apple-darwin12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
@alexmao86 Hi, I am a user of project **_com.github.sarxos:webcam-capture-example-video-recordig-humble:0.3.13-SNAPSHOT_**. I found that its pom file introduced **_13_** dependencies. However, among them, **_6_** libraries (**_46%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_com.github.sarxos:webcam-capture-example-video-recordig-humble:0.3.13-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
io.humble:humble-video-arch-i686-w64-mingw32:jar:0.2.1:compile
io.humble:humble-video-arch-x86_64-apple-darwin12:jar:0.2.1:compile
io.humble:humble-video-arch-x86_64-pc-linux-gnu6:jar:0.2.1:compile
io.humble:humble-video-arch-i686-apple-darwin12:jar:0.2.1:compile
io.humble:humble-video-arch-i686-pc-linux-gnu6:jar:0.2.1:compile
io.humble:humble-video-arch-x86_64-w64-mingw32:jar:0.2.1:compile
</code></pre>