### PR TITLE
driver-openimaj/pom.xml: use https for maven.openimaj.org

### DIFF
--- a/webcam-capture-drivers/driver-openimaj/pom.xml
+++ b/webcam-capture-drivers/driver-openimaj/pom.xml
@@ -118,7 +118,7 @@
   <repositories>
     <repository>
       <id>openimaj-maven</id>
-      <url>http://maven.openimaj.org/</url>
+      <url>https://maven.ecs.soton.ac.uk/content/repositories/thirdparty/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
* This is better for security reasons
* Recent Maven (e.g. 3.8.1) will block http url by default