### PR TITLE
Add Github Actions workflow for maven build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,25 @@
+name: Maven JVM Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        java: ['11']
+        distribution: ['temurin']
+      fail-fast: false
+    name: ${{ matrix.os }} JDK ${{ matrix.distribution }} ${{ matrix.java }}
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v1
+    - name: Set up JDK
+      id: setupjdk
+      uses: actions/setup-java@v2.2.0
+      with:
+        distribution: ${{ matrix.distribution }}
+        java-version: ${{ matrix.java }}
+    - name: Build with Maven
+      run: mvn verify


### PR DESCRIPTION
* Linux and macOS only 
* Linux and macOS builds are currently failing, but PR #840 will fix them.
* Windows fails even with PR #840, so is not included in the matrix for now
