### PR TITLE
Make the JavaFX demo sample work with a more recent version of JavaFX

### DIFF
--- a/webcam-capture-examples/webcam-capture-javafx/README.md
+++ b/webcam-capture-examples/webcam-capture-javafx/README.md
@@ -17,11 +17,17 @@ By using Maven:
 
 ```plain
 $ cd webcam-capture-examples/webcam-capture-javafx
-$ mvn clean package
+$ mvn clean install
 ```
 
-The executable JAR, together with all required dependencies (inside ```lib``` folder), 
-will be placed in ```target/jfx/app``` directory.
+## How To run
+
+After building, by using Maven:
+
+
+```plain
+$ mvn javafx:run
+```
 
 
 ## Screenshoots

--- a/webcam-capture-examples/webcam-capture-javafx/pom.xml
+++ b/webcam-capture-examples/webcam-capture-javafx/pom.xml
@@ -4,8 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>webcam-capture-examples</artifactId>
     <groupId>com.github.sarxos</groupId>
+    <artifactId>webcam-capture-examples</artifactId>
     <version>0.3.13-SNAPSHOT</version>
   </parent>
 
@@ -16,36 +16,33 @@
   <description>Example demonstrating how to use Webcam Capture API inside JavaFX
 		application without FXML. For the FXML support check other example.</description>
 
+  <properties>
+    <javafx-maven-plugin-version>0.0.8</javafx-maven-plugin-version>
+    <javafxVersion>18.0.1</javafxVersion>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.sarxos</groupId>
       <artifactId>webcam-capture</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>${javafxVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-swing</artifactId>
+      <version>${javafxVersion}</version>
+    </dependency>
   </dependencies>
 
   <build>
     <finalName>WebCamAppLauncher</finalName>
     <plugins>
-      <plugin>
-        <groupId>com.zenjava</groupId>
-        <artifactId>javafx-maven-plugin</artifactId>
-        <version>8.1.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <mainClass>WebCamAppLauncher</mainClass>
-          <bundleArguments>
-            <!-- just to w/a https://github.com/zonski/javafx-maven-plugin/pull/72 -->
-          </bundleArguments>
-        </configuration>
-      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -55,24 +52,15 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.openjfx</groupId>
+        <artifactId>javafx-maven-plugin</artifactId>
+        <version>${javafx-maven-plugin-version}</version>
+        <configuration>
+          <mainClass>WebCamAppLauncher</mainClass>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>1.7</jdk>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.oracle</groupId>
-          <artifactId>javafx</artifactId>
-          <version>2.2</version>
-          <scope>system</scope>
-          <systemPath>${java.home}/lib/jfxrt.jar</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
This PR makes the javafx capture demo up to date with more recent JavaFX versions (e.g. JavaFX 18.0.1).

Fixes #863