### PR TITLE
fix(sec): upgrade jetty-all to 9.2.27.v20190403

### DIFF
--- a/webcam-capture-examples/webcam-capture-websockets/pom.xml
+++ b/webcam-capture-examples/webcam-capture-websockets/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.eclipse.jetty.aggregate</groupId>
       <artifactId>jetty-all</artifactId>
-      <version>9.2.7.v20150116</version>
+      <version>9.2.27.v20190403</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrade jetty-all from 9.2.7.v20150116 to 9.2.27.v20190403 for vulnerability fix:

- [CVE-2015-2080](https://www.oscs1024.com/hd/MPS-2016-5010)
- [CVE-2019-10241](https://www.oscs1024.com/hd/MPS-2019-4268)
