### PR TITLE
Fix bug where webcam did not unlock during dispose.

### DIFF
--- a/webcam-capture/src/main/java/com/github/sarxos/webcam/Webcam.java
+++ b/webcam-capture/src/main/java/com/github/sarxos/webcam/Webcam.java
@@ -452,6 +452,7 @@ public class Webcam {
 		}
 
 		open.set(false);
+		lock.unlock();
 
 		LOG.info("Disposing webcam {}", getName());
 


### PR DESCRIPTION
Scenario:

1. Connect webcam
2. Disconnect webcam
3. Connect webcam again

Before fixing this bug; (3) would fail, because when it tries to open the webcam again, it will notice that the webcam was never unlocked. You would need to turn the program off then on again in order to connect to that webcam again.

I discovered and fixed this bug in my Kotlin port of this project:

<img width="929" alt="image" src="https://user-images.githubusercontent.com/5054996/204167214-aa8099a4-52a3-40b3-9267-bdcd866c38d0.png">

https://github.com/Kietyo/webcam-capture-kotlin/commit/935add096f1bc76ddd664c79d0e7a8563727434a