### PR TITLE
maven.yml: skip driver-opencv submodule (that is currently failing the build)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,4 +22,4 @@ jobs:
         distribution: ${{ matrix.distribution }}
         java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: mvn verify
+      run: mvn -pl -webcam-capture-drivers/driver-opencv verify


### PR DESCRIPTION
This module is failing the build, so this PR skips the module.

An alternative to merging this PR is to fix the broken module.