### PR TITLE
VlcDeviceTest.java: add explicit type in prep for EasyMock 5

### DIFF
--- a/webcam-capture-drivers/driver-vlcj/src/test/java/com/github/sarxos/webcam/ds/vlcj/VlcjDeviceTest.java
+++ b/webcam-capture-drivers/driver-vlcj/src/test/java/com/github/sarxos/webcam/ds/vlcj/VlcjDeviceTest.java
@@ -87,10 +87,10 @@ public class VlcjDeviceTest {
 	private VlcjDriver getDriverMock() {
 
 		List<MediaListItem> items = new ArrayList<MediaListItem>();
-		items.add(EasyMock.createMock(MediaListItem.class));
-		items.add(EasyMock.createMock(MediaListItem.class));
-		items.add(EasyMock.createMock(MediaListItem.class));
-		items.add(EasyMock.createMock(MediaListItem.class));
+		items.add(EasyMock.<MediaListItem>createMock(MediaListItem.class));
+		items.add(EasyMock.<MediaListItem>createMock(MediaListItem.class));
+		items.add(EasyMock.<MediaListItem>createMock(MediaListItem.class));
+		items.add(EasyMock.<MediaListItem>createMock(MediaListItem.class));
 		for (MediaListItem item : items) {
 			EasyMock.replay(item);
 		}


### PR DESCRIPTION
Change:

	items.add(EasyMock.createMock(MediaListItem.class));

to

	items.add(EasyMock.<MediaListItem>createMock(MediaListItem.class));

in 4 places.