### PR TITLE
driver-opencv/pom.xml: remove org.bytedeco:videoinput exclusion

### DIFF
--- a/webcam-capture-drivers/driver-opencv/pom.xml
+++ b/webcam-capture-drivers/driver-opencv/pom.xml
@@ -42,10 +42,6 @@
       	</exclusion>
       	<exclusion>
       		<groupId>org.bytedeco</groupId>
-      		<artifactId>videoinput</artifactId>
-      	</exclusion>
-      	<exclusion>
-      		<groupId>org.bytedeco</groupId>
       		<artifactId>openblas</artifactId>
       	</exclusion>
       	<exclusion>


### PR DESCRIPTION
This should fix the Github Actions build, I'm not sure why this was excluded -- maybe there was a good reason?