### PR TITLE
maven-surefire-plugin config add-opens (for JDK 17)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>2.7</version>

--- a/webcam-capture-drivers/driver-opencv/pom.xml
+++ b/webcam-capture-drivers/driver-opencv/pom.xml
@@ -42,10 +42,6 @@
       	</exclusion>
       	<exclusion>
       		<groupId>org.bytedeco</groupId>
-      		<artifactId>videoinput</artifactId>
-      	</exclusion>
-      	<exclusion>
-      		<groupId>org.bytedeco</groupId>
       		<artifactId>openblas</artifactId>
       	</exclusion>
       	<exclusion>


### PR DESCRIPTION
Add `add-opens` configuration option to `pom.xml` for the `maven-surefire-plugin` to support building with JDK 17.

There are issues with PowerMock in the `driver-vlcj` module that must also be addressed to get a JDK 17 build working, but this fix does not affect the JDK 11 build.

Note: This commit is based on PR #892 (to make it easy to verify that the JDK 11 build still works)