### PR TITLE
Github Actions maven.yml: Add java 17 to matrix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        java: ['11']
+        java: ['11', '17']
         distribution: ['temurin']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.distribution }} ${{ matrix.java }}

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>2.7</version>

--- a/webcam-capture-drivers/driver-opencv/pom.xml
+++ b/webcam-capture-drivers/driver-opencv/pom.xml
@@ -42,10 +42,6 @@
       	</exclusion>
       	<exclusion>
       		<groupId>org.bytedeco</groupId>
-      		<artifactId>videoinput</artifactId>
-      	</exclusion>
-      	<exclusion>
-      		<groupId>org.bytedeco</groupId>
       		<artifactId>openblas</artifactId>
       	</exclusion>
       	<exclusion>


### PR DESCRIPTION
Add Java 17 to the matrix in `maven.yml`.

There is currently an issue with Powermock and Java 17 that prevent the `driver-vlcj` module from successfully running tests, so this PR currently breaks the build. (I'm not sure how to fix the PowerMock issue, I'm hoping someone with more knowledge of PowerMock and/or the tests in `driver-vlcj` that use it will provide a solution.)

This PR depends upon PR #893 (so that the GitHub Actions build proceeds far enough to illustrate the remaining issue in `driver-vlcj`)