### PR TITLE
[v4l4j Driver] Resolved bug which failed the initialisation of all video devices if a single video file could not be opened correctly.

### DIFF
--- a/webcam-capture-drivers/driver-v4l4j/src/main/java/com/github/sarxos/webcam/ds/v4l4j/V4l4jDriver.java
+++ b/webcam-capture-drivers/driver-v4l4j/src/main/java/com/github/sarxos/webcam/ds/v4l4j/V4l4jDriver.java
@@ -46,7 +46,13 @@ public class V4l4jDriver implements WebcamDriver {
 		}
 
 		for (File vfile : vfiles) {
-			devices.add(new V4l4jDevice(vfile));
+			try {
+				devices.add(new V4l4jDevice(vfile));
+			} catch (WebcamException e) {
+				if (LOG.isDebugEnabled()) {
+					LOG.error("An exception occurred whilst trying to initialise video device file {}", vfile.toString(), e);
+				}
+			}
 		}
 
 		return devices;


### PR DESCRIPTION
`getWebcams()` and all related forms of the method would fail on the v4l4j driver in the case that there was a single video file under /dev that was not a functional video camera - this pull request attempts to resolve that problem whilst maintaining a suitable level of error reporting.